### PR TITLE
encode: autogenerate the boundary by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ local b,c,h = H(rq)
 See [LuaSocket](http://w3.impa.br/~diego/software/luasocket/http.html)'s
 `http.request` (generic interface) for more information.
 
+If you only need to get the multipart/form-data body use `encode`:
+
+```lua
+local enc = (require "multipart-post").encode
+local body, boundary = enc{foo="bar"}
+-- use `boundary` to build the Content-Type header
+```
+
 ## Bugs
 
 Non-ASCII part names and file names are not supported.

--- a/multipart-post.lua
+++ b/multipart-post.lua
@@ -37,6 +37,7 @@ local gen_boundary = function()
 end
 
 local encode = function(t, boundary)
+  boundary = boundary or gen_boundary()
   local r = {}
   local _t
   for k,v in pairs(t) do
@@ -56,7 +57,7 @@ local encode = function(t, boundary)
     else error(string.format("unexpected type %s", _t)) end
   end
   tprintf(r, "--%s--\r\n", boundary)
-  return table.concat(r)
+  return table.concat(r), boundary
 end
 
 local gen_request = function(t)


### PR DESCRIPTION
Useful e.g. to send the request via another HTTP client.
