### PR TITLE
Fix compatibility with Lua 5.1 and LuaJIT

### DIFF
--- a/multipart-post.lua
+++ b/multipart-post.lua
@@ -1,6 +1,10 @@
 local ltn12 = require "ltn12"
 local url = require "socket.url"
 
+--luacheck: push ignore 143
+local unpack = table.unpack or unpack
+--luacheck: pop
+
 local _M = {}
 
 _M.CHARSET = "UTF-8"
@@ -139,7 +143,7 @@ local function source(t, boundary, ctx)
         n = n + 3
     end
     sources[n] = ltn12.source.string(string.format("--%s--\r\n", boundary))
-    return ltn12.source.cat(table.unpack(sources))
+    return ltn12.source.cat(unpack(sources))
 end
 _M.source = source
 


### PR DESCRIPTION
`table.unpack` was not available in Lua 5.1 (and so not available in LuaJIT).
Instead there was a global function named `unpack`, which provides almost the same functionality.

I've simply defined `local unpack = table.unpack or unpack` which should select `table.unpack` available, and fall back to `unpack`  when not.

You may also notice 2 comment lines, they're for luacheck to not complain about `table.unpack` is not available.

I hope you accept the pull request and update the luarocks module, because I'm depending on it in my library, and I had to include the modified `multipart-post.lua` instead of adding it as a luarocks dependency.